### PR TITLE
Apply domain public ACL for synonyms

### DIFF
--- a/end-to-end/connector/pom.xml
+++ b/end-to-end/connector/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
@@ -57,6 +57,12 @@
       <artifactId>truth</artifactId>
       <version>0.40</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/identity/connector/sdk/full-sync/pom.xml
+++ b/identity/connector/sdk/full-sync/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-identity-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/indexing/connector/sdk/acls/pom.xml
+++ b/indexing/connector/sdk/acls/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
     <!-- [END cloud_search_indexing_sdk_maven] -->
 
@@ -60,6 +60,12 @@
       <artifactId>truth</artifactId>
       <version>0.42</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.jimfs</groupId>

--- a/indexing/connector/sdk/dictionary-connector/pom.xml
+++ b/indexing/connector/sdk/dictionary-connector/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
     <dependency>
         <groupId>org.apache.commons</groupId>
@@ -53,6 +53,12 @@
       <artifactId>truth</artifactId>
       <version>0.40</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/indexing/connector/sdk/dictionary-connector/sample-config.properties
+++ b/indexing/connector/sdk/dictionary-connector/sample-config.properties
@@ -4,16 +4,11 @@ api.sourceId=
 # Path to service account credentials
 api.serviceAccountPrivateKeyFile=
 
-# All items public by default
-defaultAcl.mode=FALLBACK
-defaultAcl.public=true
-
 # This simple sample only needs to run one time and exit
 connector.runOnce=true
 
 # Well-known schemas aren't exposed in API, need to define locally
 structuredData.localSchema=schema.json
-
 
 # Number of synthetic documents to create
 dictionary.file=dictionary.csv

--- a/indexing/connector/sdk/full-traversal/pom.xml
+++ b/indexing/connector/sdk/full-traversal/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -48,6 +48,12 @@
       <artifactId>truth</artifactId>
       <version>0.40</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/indexing/connector/sdk/graph-traversal/pom.xml
+++ b/indexing/connector/sdk/graph-traversal/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -48,6 +48,12 @@
       <artifactId>truth</artifactId>
       <version>0.40</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/indexing/connector/sdk/list-traversal/pom.xml
+++ b/indexing/connector/sdk/list-traversal/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
       <artifactId>google-cloudsearch-indexing-connector-sdk</artifactId>
-      <version>v1-0.0.2</version>
+      <version>v1-0.0.3</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -48,6 +48,12 @@
       <artifactId>truth</artifactId>
       <version>0.40</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
For synonyms, only domain public ACLs are applicable.

Additional changes :
1. Bumped SDK version to v1-0.0.3
2. Exclude guava from truth to avoid conflict with version available
with SDK.