### PR TITLE
Adding reference to main doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This repository contains end-to-end samples for Cloud Search, including
 indexing, structured data management, and querying.
 
+For more info on Cloud Search please see https://developers.google.com/cloud-search/
+
 ## Contributing changes
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Feedback was to add reference to main doc page so that people would go there and sign up for Cloud Search in the event of error.