### PR TITLE
Fix documentation link

### DIFF
--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -13,4 +13,4 @@ configure and deploy the tutorial.
 [cloudshell-badge]: http://gstatic.com/cloudssh/images/open-btn.png
 [cloudshell-open]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/gsuitedevs/cloud-search-samples&page=editor&open_in_editor=end-to-end/README.md
 [cloud-search]: https://developers.google.com/cloud-search/
-[tutorial-url]: https://developers.google.com/cloud-search/docs/guides/tutorials/end-to-end
+[tutorial-url]: https://developers.google.com/cloud-search/docs/tutorials/end-to-end/


### PR DESCRIPTION
The link to the end-to-end tutorial is outdated, this updates it.


- Neil (satra@)