### PR TITLE
Allow dictionary connector to create search-app-specific synonyms

### DIFF
--- a/indexing/connector/sdk/dictionary-connector/sample-config.properties
+++ b/indexing/connector/sdk/dictionary-connector/sample-config.properties
@@ -12,3 +12,6 @@ structuredData.localSchema=schema.json
 
 # Number of synthetic documents to create
 dictionary.file=dictionary.csv
+
+# Whether synonyms should be specific to search applications containing them
+dictionary.attachedToSearchApp=false

--- a/indexing/connector/sdk/dictionary-connector/schema.json
+++ b/indexing/connector/sdk/dictionary-connector/schema.json
@@ -20,7 +20,16 @@
               "operatorName": "not_used"
             }
           }
-        }
+        },
+        {
+          "name": "_onlyApplicableForAttachedSearchApplications",
+          "isRepeatable": false,
+          "booleanPropertyOptions": {
+            "operatorOptions": {
+              "operatorName": "not_used"
+            }
+          }
+        }        
       ]
     }
   ]

--- a/indexing/connector/sdk/dictionary-connector/src/main/java/com/google/cloudsearch/samples/DictionaryConnector.java
+++ b/indexing/connector/sdk/dictionary-connector/src/main/java/com/google/cloudsearch/samples/DictionaryConnector.java
@@ -197,6 +197,10 @@ public class DictionaryConnector {
       Multimap<String, Object> structuredData = ArrayListMultimap.create();
       structuredData.put("_term", term);
       structuredData.putAll("_synonym", synonyms);
+      
+      if (Configuration.getBoolean("dictionary.attachedToSearchApp", false).get()) {
+        structuredData.put("_onlyApplicableForAttachedSearchApplications", true);
+      }
 
       String itemName = String.format("dictionary/%s", term);
 


### PR DESCRIPTION
Add a new config key and update the local schema file so that the sample dictionary connector can optionally index synonyms which are restricted to attached search applications.

Cloud Search recently added a new property to the dictionary entry well-known schema, "_onlyApplicableForAttachedSearchApplications". If this boolean value is true for a synonym item, the synonym is only applied to search applications containing the synonym's data source. Otherwise, the default behavior is for a synonym to apply to all search applications at the domain.

More details at: https://developers.google.com/cloud-search/docs/guides/synonyms